### PR TITLE
Set global group for additionDirectory if not explicitly specified

### DIFF
--- a/src/main/java/de/douglas/maven/plugin/rpmsystemd/rpm/PostInstMojo.java
+++ b/src/main/java/de/douglas/maven/plugin/rpmsystemd/rpm/PostInstMojo.java
@@ -72,7 +72,7 @@ public class PostInstMojo extends AbstractMojo {
             if(dirConf.getDirectory() == null) throw new MojoFailureException("<additionalDirectory> element must contain the directory");
 
             if(dirConf.getUser() == null) dirConf.setUser(user);
-            if(dirConf.getGroup() == null) dirConf.setUser(group);
+            if(dirConf.getGroup() == null) dirConf.setGroup(group);
         }
     }
 }

--- a/src/test/java/de/douglas/maven/plugin/rpmsystemd/rpm/PostInstMojoTest.java
+++ b/src/test/java/de/douglas/maven/plugin/rpmsystemd/rpm/PostInstMojoTest.java
@@ -76,6 +76,23 @@ public class PostInstMojoTest extends AbstractHarnessMojoTestCase {
         );
     }
 
+    public void testGenerateRpmPostInstFileWithAdditionalDirectoriesWithoutUserAndGroup() throws Exception {
+        final Path testBaseDir = createDir(postInstTestsBaseDir.resolve("additional-directories-without-user-and-group"));
+        createDir(testBaseDir.resolve("target"));
+
+        File pom = getTestFile(postInstSrcDir.resolve("pom-additional-directories-without-user-and-group.xml").toString());
+
+        PostInstMojo postInstMojo = (PostInstMojo) lookupMojo("generate-rpm-postinst-file", pom);
+        postInstMojo.execute();
+
+        assertTrue(
+                "Generated postinst file does not equal expected one", FileUtils.contentEquals(
+                        postInstSrcDir.resolve("postinst-additional-directories-without-user-and-group-expected").toFile(),
+                        testBaseDir.resolve("target").resolve("rpm-systemd-maven-plugin").resolve("postinst").toFile()
+                )
+        );
+    }
+
     public void tearDown() throws IOException {
         FileUtils.deleteDirectory(postInstTestsBaseDir.toFile());
     }

--- a/src/test/resources/unit/rpm-systemd-maven-plugin/postinst/pom-additional-directories-without-user-and-group.xml
+++ b/src/test/resources/unit/rpm-systemd-maven-plugin/postinst/pom-additional-directories-without-user-and-group.xml
@@ -1,0 +1,31 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>de.douglas.maven.plugin</groupId>
+    <artifactId>rpm-systemd-maven-plugin-test-module</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>RPM Systemd Maven Plugin - Test module</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>rpm-systemd-maven-plugin</artifactId>
+                <configuration>
+                    <baseDirectory>target/test-harness/rpm-systemd-maven-plugin/postinst/additional-directories-without-user-and-group</baseDirectory>
+                    <workingDirectoryPath>/path/to/workingDirectory</workingDirectoryPath>
+                    <environmentFilePath>/environmentfile</environmentFilePath>
+                    <systemdServiceFileName>some.service</systemdServiceFileName>
+                    <user>makubi</user>
+                    <group>some-group</group>
+                    <additionalDirectories>
+                        <additionalDirectory>
+                            <directory>/path/to/some/directory</directory>
+                        </additionalDirectory>
+                    </additionalDirectories>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/test/resources/unit/rpm-systemd-maven-plugin/postinst/postinst-additional-directories-without-user-and-group-expected
+++ b/src/test/resources/unit/rpm-systemd-maven-plugin/postinst/postinst-additional-directories-without-user-and-group-expected
@@ -1,0 +1,12 @@
+
+test -f /environmentfile || echo 'JAVA_OPTS=""' > /environmentfile
+getent group some-group || groupadd -r some-group >/dev/null 2>&1
+getent passwd makubi || useradd -s /bin/false -d /path/to/workingDirectory -g some-group -r -m makubi >/dev/null 2>&1
+
+test -d /path/to/workingDirectory || mkdir /path/to/workingDirectory >/dev/null 2>&1
+test -d /path/to/workingDirectory && chown -R makubi:some-group /path/to/workingDirectory >/dev/null 2>&1
+
+/usr/bin/systemctl preset some.service >/dev/null 2>&1
+
+test -d /path/to/some/directory || mkdir /path/to/some/directory >/dev/null 2>&1
+test -d /path/to/some/directory && chown -R makubi:some-group /path/to/some/directory >/dev/null 2>&1


### PR DESCRIPTION
PostInstMojo sets the group for <additionalDirectory>s (if not
explicitly specified for the given <additionalDirector>) instead of
overwriting the user with the configured group.
